### PR TITLE
Shader - Translation Typo

### DIFF
--- a/pages/plasticity-essentials/shader-mode.de.mdx
+++ b/pages/plasticity-essentials/shader-mode.de.mdx
@@ -60,7 +60,7 @@ import { Tabs } from 'nextra/components'
 
 <Callout emoji="❗">
 **Note**     
-- Make sure you enable the option to view hidden folders in your operating system to access the `.plasticity` directory.
+- Stellen Sie sicher, dass Sie die Option zum Anzeigen versteckter Ordner in Ihrem Betriebssystem aktivieren, um auf das Verzeichnis `.plasticity` zuzugreifen.
 </Callout>
 
 ### Zeige Kanten, Kurven und Flächen ein- oder ausblenden

--- a/pages/plasticity-essentials/shader-mode.en.mdx
+++ b/pages/plasticity-essentials/shader-mode.en.mdx
@@ -60,7 +60,7 @@ import { Tabs } from 'nextra/components'
 
 <Callout emoji="❗">
 **Note**     
-- Stellen Sie sicher, dass Sie die Option zum Anzeigen versteckter Ordner in Ihrem Betriebssystem aktivieren, um auf das Verzeichnis `.plasticity` zuzugreifen.
+- Make sure you enable the option to view hidden folders in your operating system to access the `.plasticity` directory.
 </Callout>
 
 ### Toggle Show Edges, Curves, and Faces


### PR DESCRIPTION
One of the translations DE and EN were swapped - I corrected this. 