### PR TITLE
docs: add search placeholder translations so it does not say undefined

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -48,6 +48,19 @@ const config: DocsThemeConfig = {
     gitTimestamp: ({ timestamp }) => (
         <span>Last updated on {timestamp.toLocaleDateString()}</span>
     ),
+    search: {
+        placeholder: () => {
+            const router = useRouter();
+            const { locale } = router;
+            const translations = {
+                en: "Search documentation...",
+                de: "Dokumentation durchsuchen...",
+                ja: "ドキュメントを検索..."
+            };
+
+            return translations[locale] || translations.en;
+        }
+    },
     useNextSeoProps() {
         const { asPath } = useRouter();
         if (asPath !== "/" && asPath !== "/ja" && asPath !== "/en") {


### PR DESCRIPTION
# Overview

Documentation search input field says `undefined...` for placeholder text. This pull request adds the translations by updating the theme config.

## Before (in production)

![plasticity-docs-before](https://github.com/user-attachments/assets/df3f4241-adc5-4030-baa8-1c839c988815)


## After

![plasticity-docs-after](https://github.com/user-attachments/assets/2104207d-28fb-4dfa-8ac8-a33ee008e851)
